### PR TITLE
Vanilla Mace BC Config

### DIFF
--- a/arsenal-common/src/main/resources/data/tm_arsenal/miapi/modules/blade/mace.json
+++ b/arsenal-common/src/main/resources/data/tm_arsenal/miapi/modules/blade/mace.json
@@ -73,7 +73,7 @@
     ],
     "rarity": "epic",
     "durability": "400",
-    "better_combat_config": "bettercombat:mace",
+    "better_combat_config": "bettercombat:vanilla_mace",
     "gui_offset": {
         "sizeX": -2,
         "sizeY": -2


### PR DESCRIPTION
Use bettercombat:vanilla_mace instead of bettercombat:mace as the mace module's config.